### PR TITLE
Bugfix in convert_qg_datasets.py, type of train-test-split argument must be specified

### DIFF
--- a/utils/convert_qg_datasets.py
+++ b/utils/convert_qg_datasets.py
@@ -125,7 +125,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser('Convert qg benchmark datasets')
     parser.add_argument('-i', '--inputdir', required=True, help='Directory of input numpy files.')
     parser.add_argument('-o', '--outputdir', required=True, help='Output directory.')
-    parser.add_argument('--train-test-split', default=0.9, help='Training / testing split fraction.')
+    parser.add_argument('--train-test-split', type=float, default=0.9, help='Training / testing split fraction.')
     args = parser.parse_args()
 
     import glob


### PR DESCRIPTION
Hi, this is just pushing back a quick fix that I had to make to get this script running -- if the type of the `train-test-split` argument is not specified, the script does not run.

--MLB
